### PR TITLE
Allow an empty apikey

### DIFF
--- a/lib/SurveyMonkey.php
+++ b/lib/SurveyMonkey.php
@@ -79,10 +79,6 @@ class SurveyMonkey
      */
     public function __construct($apiKey, $accessToken, $options = array(), $connectionOptions = array())
     {
-        if (empty($apiKey)) {
-            throw new SurveyMonkey_Exception('Missing apiKey');
-        }
-
         if (empty($accessToken)) {
             throw new SurveyMonkey_Exception('Missing accessToken');
         }
@@ -140,7 +136,9 @@ class SurveyMonkey
      */
     protected function buildUri($method)
     {
-        return $this->_protocol . '://' . $this->_hostname . '/' . $this->_version . '/' . $method . '?api_key=' . $this->_apiKey;
+        $apiKeyParam = $this->_apiKey ? 'api_key=' . $this->_apiKey : '';
+
+        return $this->_protocol . '://' . $this->_hostname . '/' . $this->_version . '/' . $method . '?' . $apiKeyParam;
     }
 
     /**


### PR DESCRIPTION
SurveyMonkey has updated its authentication to remove the use of API keys. See: https://developer.surveymonkey.com/api/v3/#authentication

> We’ve updated our authentication and are no longer using Mashery. We now generate a unique client id that is not your Mashery username, and we’ve removed the use of API keys. If you’re registering a new app or refreshing your credentials, you should follow the NEW Authentication flow. If you created your app before Nov 1st, 2016, your existing credentials will continue to work as outlined in OLD Authentication, as long as you don’t refresh them in our developer portal.

If you attempt to use the surveymonkey with an API in these circumstances, it will return an error:

> Error [400]: {"error": {"docs": "https://developer.surveymonkey.com/api/v3/#error-codes", "message": "API key is not required for this app.", "id": "1000", "name": "Bad Request", "http_status_code": 400}}

This patch simply removes the empty check for the API config param, allowing users to provide a null apikey